### PR TITLE
Hotfix/dark theme icon background

### DIFF
--- a/packages/Icon/docs/IconList.vue
+++ b/packages/Icon/docs/IconList.vue
@@ -49,7 +49,7 @@ const icons = computed(() => {
 	flex-direction: column;
 	align-items: center;
 	gap: 1rem;
-	background: white;
+	background: var(--c-bg);
 	padding: 1.25rem;
 
 	.orion-icon {

--- a/sandbox/views/packages/IconView.vue
+++ b/sandbox/views/packages/IconView.vue
@@ -53,4 +53,9 @@ const state = reactive({ loading: false });
 		font-size: 24px;
 	}
 }
+
+[data-orion-theme='dark']
+.demo-icon {
+	background: var(--grey-light);
+}
 </style>


### PR DESCRIPTION
This pull request addresses an issue with the background color of the icon containers in dark mode in the documentation and sandbox.

**Issue**
In dark mode, the background color of the icon containers was not correct, making the icons difficult to read.

![CleanShot 2023-05-16 at 21 39 38](https://github.com/orion-ui/orion-ui/assets/41829587/19e936a8-5d7d-4acc-a48a-1da3572687c7)

**Solution**
I've adjusted the CSS colors to match the expected ones in dark mode. This improves the visibility of the icons in dark mode.

![CleanShot 2023-05-16 at 21 39 57](https://github.com/orion-ui/orion-ui/assets/41829587/2bc31beb-e0b4-4f76-aa6e-1b97a54ef64e)

**Testing**
I have tested these changes in both the documentation and sandbox sections of the site by toggling between light and dark modes. The icons are now displayed correctly in dark mode.

I'm open to any suggestions or necessary adjustments.
