### PR TITLE
feat(aside): update layout and moove actions + footer like DS

### DIFF
--- a/packages/Aside/docs/AsideNested.vue
+++ b/packages/Aside/docs/AsideNested.vue
@@ -12,6 +12,7 @@ import NestedComp from './NestedComp.vue';
 
 function showProgrammaticAside () {
 	useAside({
+		title: 'Aside title',
 		Nested: NestedComp,
 		NestedProps: { title: 'Title from nested props' },
 	});
@@ -26,6 +27,7 @@ function showProgrammaticAside () {
 You can insert an existing component in the aside with the property `Nested`.
 
 Props can be passed to the nested component with the property `NestedProps`.
+If you need a title in the aside header, use `options.title`.
 
 Take a look at the source code below.
 
@@ -40,6 +42,8 @@ In the `script` part of your nested component : `const _aside = inject('_aside')
 Il est possible d'imbriquer un composant existant dans l'aside avec la propriété `Nested`.
 
 Les props peuvent être passées à ce composant avec la propriété `NestedProps`.
+
+Si vous avez besoin d'un titre dans l'en-tÇ¸te de l'aside, utilisez `options.title`.
 
 Jetez un oeil au code source ci-dessous.
 

--- a/packages/Aside/docs/AsideNested.vue
+++ b/packages/Aside/docs/AsideNested.vue
@@ -13,6 +13,7 @@ import NestedComp from './NestedComp.vue';
 function showProgrammaticAside () {
 	useAside({
 		title: 'Aside title',
+		description: 'This aside contains a nested component.',
 		Nested: NestedComp,
 		NestedProps: { title: 'Title from nested props' },
 	});
@@ -43,7 +44,7 @@ Il est possible d'imbriquer un composant existant dans l'aside avec la propriét
 
 Les props peuvent être passées à ce composant avec la propriété `NestedProps`.
 
-Si vous avez besoin d'un titre dans l'en-tÇ¸te de l'aside, utilisez `options.title`.
+Si vous avez besoin d'un titre dans l'en-tête de l'aside, utilisez `options.title`.
 
 Jetez un oeil au code source ci-dessous.
 

--- a/packages/Aside/docs/AsidePlayground.vue
+++ b/packages/Aside/docs/AsidePlayground.vue
@@ -47,6 +47,7 @@ const state = reactive({
 	hideClose: false,
 	hideOnOverlayClick: true,
 	title: 'Lorem ipsum',
+	description: 'This is a description for the aside.',
 	overlay: true,
 });
 

--- a/packages/Aside/docs/AsideSlots.vue
+++ b/packages/Aside/docs/AsideSlots.vue
@@ -15,6 +15,9 @@
 		<o-aside
 			ref="_asideA"
 			:options="{ title: 'This is the Title', description: 'This is an aside with a description' }">
+			<template #header>
+				<span class="text--primary">Here</span> comes your <span class="text--primary">header slot content</span>
+			</template>
 			<o-section title="Aside with actions">
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 				Duis sagittis viverra vulputate. Nunc ultricies ante urna, eget.
@@ -31,17 +34,19 @@
 				<o-button
 					outline>
 					Cancel
-					</o-button>
+				</o-button>
 				<o-button
 					color="info">
 					Save
-					</o-button>
+				</o-button>
 			</teleport>
 		</o-aside>
 
-		<o-aside ref="_asideB" :options="{ title: 'This is the Title', description: 'This is an aside with a description' }">
+		<o-aside
+			ref="_asideB"
+			:options="{ title: 'This is the Title', description: 'This is an aside with a description' }">
 			<template #footer>
-					<span class="text--primary">Here</span> comes your <span class="text--primary">footer content</span>
+				<span class="text--primary">Here</span> comes your <span class="text--primary">footer content</span>
 			</template>
 
 			<o-section title="Aside with footer">
@@ -55,7 +60,9 @@
 			</o-section>
 		</o-aside>
 
-		<o-aside ref="_asideC" :options="{ title: 'This is the Title', description: 'This is an aside with a description' }">
+		<o-aside
+			ref="_asideC"
+			:options="{ title: 'This is the Title', description: 'This is an aside with a description' }">
 			<template #poster>
 				<img
 					src="https://picsum.photos/id/1041/200"

--- a/packages/Aside/docs/AsideSlots.vue
+++ b/packages/Aside/docs/AsideSlots.vue
@@ -29,22 +29,19 @@
 				v-if="_asideA"
 				:to="_asideA?.slotActions">
 				<o-button
-					prefix-icon="check"
-					color="success"/>
+					outline>
+					Cancel
+					</o-button>
 				<o-button
-					prefix-icon="camera"
-					color="info"/>
+					color="info">
+					Save
+					</o-button>
 			</teleport>
 		</o-aside>
 
-		<o-aside ref="_asideB">
+		<o-aside ref="_asideB" :options="{ title: 'This is the Title', description: 'This is an aside with a description' }">
 			<template #footer>
-				<o-alert
-					color="primary"
-					center
-					title="Aside footer slot">
-					Here comes your footer content
-				</o-alert>
+					<span class="text--primary">Here</span> comes your <span class="text--primary">footer content</span>
 			</template>
 
 			<o-section title="Aside with footer">
@@ -58,7 +55,7 @@
 			</o-section>
 		</o-aside>
 
-		<o-aside ref="_asideC">
+		<o-aside ref="_asideC" :options="{ title: 'This is the Title', description: 'This is an aside with a description' }">
 			<template #poster>
 				<img
 					src="https://picsum.photos/id/1041/200"

--- a/packages/Aside/docs/NestedComp.vue
+++ b/packages/Aside/docs/NestedComp.vue
@@ -1,5 +1,7 @@
 <template>
-	<o-section :title="`${title} ${uid ?? ''}`" subtitle="This is a nested component inside an aside.">
+	<o-section
+		:title="`${title} ${uid ?? ''}`"
+		subtitle="This is a nested component inside an aside.">
 		<p>
 			Etiam porta sem malesuada magna mollis euismod.
 			Etiam porta sem malesuada magna mollis euismod.
@@ -15,10 +17,8 @@
 			Vestibulum id ligula porta felis euismod semper.
 			Nulla vitae elit libero, a pharetra augue.
 		</p>
-		<teleport
-			v-if="_aside?.slotActions"
-			defer
-			:to="_aside.slotActions">
+
+		<teleport :to="_aside?.slotActions">
 			<o-button
 				v-if="uid"
 				color="warning"
@@ -39,12 +39,16 @@
 				Open a new aside
 			</o-button>
 		</teleport>
+
+		<teleport :to="_aside?.slotFooter">
+			This is the footer from the nested component.
+		</teleport>
 	</o-section>
 </template>
 
 <script setup lang="ts">
+import { getUid, useAside } from 'lib';
 import { inject } from 'vue';
-import { useAside, getUid } from 'lib';
 import NestedComp from './NestedComp.vue';
 
 defineProps<{ title: string, uid?: number }>();

--- a/packages/Aside/docs/NestedComp.vue
+++ b/packages/Aside/docs/NestedComp.vue
@@ -1,5 +1,5 @@
 <template>
-	<o-section :title="`${title} ${uid ?? ''}`">
+	<o-section :title="`${title} ${uid ?? ''}`" subtitle="This is a nested component inside an aside.">
 		<p>
 			Etiam porta sem malesuada magna mollis euismod.
 			Etiam porta sem malesuada magna mollis euismod.
@@ -15,29 +15,30 @@
 			Vestibulum id ligula porta felis euismod semper.
 			Nulla vitae elit libero, a pharetra augue.
 		</p>
-	</o-section>
+		<teleport
+			v-if="_aside?.slotActions"
+			defer
+			:to="_aside.slotActions">
+			<o-button
+				v-if="uid"
+				color="warning"
+				outline
+				@click="_aside?.close({ flush: true })">
+				Close and flush queue
+			</o-button>
 
-	<o-section align="right">
-		<o-button
-			v-if="uid"
-			color="warning"
-			outline
-			@click="_aside?.close({ flush: true })">
-			Close and flush queue
-		</o-button>
+			<o-button
+				outline
+				@click="_aside?.close()">
+				Close aside
+			</o-button>
 
-		<o-button
-			color="danger"
-			outline
-			@click="_aside?.close()">
-			Close aside
-		</o-button>
-
-		<o-button
-			color="info"
-			@click="openNew()">
-			Open a new aside
-		</o-button>
+			<o-button
+				color="info"
+				@click="openNew()">
+				Open a new aside
+			</o-button>
+		</teleport>
 	</o-section>
 </template>
 

--- a/packages/Aside/src/OrionAside.less
+++ b/packages/Aside/src/OrionAside.less
@@ -9,9 +9,9 @@
 .orion-aside {
 	transition: box-shadow 0.3s;
 	position: fixed;
-	top: var(--o-space-24);
-	right: var(--o-space-24);
-	bottom: var(--o-space-24);
+	top: var(--o-space-8);
+	right: var(--o-space-8);
+	bottom: var(--o-space-8);
 	border-radius: var(--o-radius-md);
 	max-width: calc(100vw - 2.5rem);
 	display: none;
@@ -42,29 +42,20 @@
 	}
 
 	&__header {
-		padding: var(--o-space-24) var(--o-space-24);
+		padding: var(--o-space-8);
 		display: flex;
 		position: relative;
 		flex-direction: column;
-		border-radius: var(--o-radius-md);
+		border-top-left-radius: var(--o-radius-md);
+		border-top-right-radius: var(--o-radius-md);
 		gap: var(--o-space-8);
 		background-color: var(--o-background-neutral-default);
+		border-bottom: 1px solid var(--o-border-neutral-default);
 
-		&:has(+ .orion-aside__body),
-		&:has(+ .orion-aside__footer) {
-			padding-bottom: 0;
-		}
-
-		@media @tablet {
-			padding: var(--o-space-24) var(--o-space-24);
-		}
-
-		.orion-aside--sm & {
-			padding: var(--o-space-24) var(--o-space-24);
-		}
-
-		.orion-aside--xs & {
-			padding: var(--o-space-24);
+		.orion-aside__header-container {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
 		}
 
 		&:empty {
@@ -77,8 +68,14 @@
 	}
 
 	&__title {
-		.typography(heading-h5);
-		margin: 0;
+		padding-left: var(--o-space-16);
+		.typography(subtitle-bold);
+	}
+
+	&__description {
+		.typography(body2-default);
+		color: var(--o-text-default-subtle);
+		padding: 0 var(--o-space-16);
 	}
 
 	&__logo {
@@ -98,21 +95,6 @@
 		}
 	}
 
-	&__actions {
-		display: flex;
-		flex-direction: column;
-		position: absolute;
-		align-items: flex-start;
-		gap: 1rem;
-		right: calc(100% + 1rem);
-		top: 2rem;
-
-		.orion-button {
-			width: unset;
-			box-shadow: 0 0.3rem 1rem -0.3rem fade(black, 40);
-		}
-	}
-
 	&__body,
 	&__footer {
 		overflow: auto;
@@ -128,30 +110,26 @@
 		max-width: 100%;
 		max-height: 100%;
 
-		.orion-aside__header:not(:empty)+& {
-			padding-top: 0;
-		}
-
 
 		// #region Pure CSS scroll shadow
 		background: linear-gradient(white 30%, rgba(255, 255, 255, 0)),
-		linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
-		radial-gradient(farthest-side at 50% 0,
-			rgba(0, 0, 0, 0),
-			rgba(0, 0, 0, 0)),
-		radial-gradient(farthest-side at 50% 100%,
-			rgba(0, 0, 0, 0.2),
-			rgba(0, 0, 0, 0)) 0 100%;
+			linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
+			radial-gradient(farthest-side at 50% 0,
+				rgba(0, 0, 0, 0),
+				rgba(0, 0, 0, 0)),
+			radial-gradient(farthest-side at 50% 100%,
+				rgba(0, 0, 0, 0.2),
+				rgba(0, 0, 0, 0)) 0 100%;
 		background-repeat: no-repeat;
 		background-color: var(--o-background-neutral-default);
 		background-size: 100% 2.5rem,
-		100% 2.5rem,
-		100% 0,
-		100% 0.5rem;
+			100% 2.5rem,
+			100% 0,
+			100% 0.5rem;
 		background-attachment: local,
-		local,
-		scroll,
-		scroll;
+			local,
+			scroll,
+			scroll;
 
 		[data-orion-theme='dark'] & {
 			background:
@@ -190,12 +168,31 @@
 		}
 	}
 
-	&__footer {
+	&__actions {
 		order: 3;
-		flex: 0 0 auto;
-		border: 1px solid var(--o-border-neutral-default);
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--o-space-8);
 		padding: var(--o-space-16) var(--o-space-24);
+		border-top: 1px solid var(--o-border-neutral-default);
 		border-radius: 0 0 var(--o-radius-md) var(--o-radius-md);
+
+		&:empty {
+			display: none;
+		}
+	}
+
+	&__footer {
+		order: 4;
+		display: flex;
+		flex: 0 0 auto;
+		gap: var(--o-space-8);
+		padding: var(--o-space-16) var(--o-space-24);
+		border-top: 1px solid var(--o-border-neutral-default);
+		border-radius: 0 0 var(--o-radius-md) var(--o-radius-md);
+		background: var(--o-background-neutral-minimal);
+		color: var(--o-text-default-subtle);
+
 
 		@media @tablet {
 			padding: var(--o-space-16) var(--o-space-24);
@@ -214,20 +211,7 @@
 		}
 	}
 
-	&__close {
-		.close(1.5rem);
-		z-index: 1;
-		position: absolute;
-		color: var(--o-text-default-subtle);
-		top: var(--o-space-16);
-		right: var(--o-space-16);
-		background: var(--o-background-neutral-default);
-
-		@media @tablet {
-			top: var(--o-space-24);
-			right: var(--o-space-24);
-		}
-	}
+	.orion-aside__close {}
 
 	&--visible {
 		display: flex;

--- a/packages/Aside/src/OrionAside.less
+++ b/packages/Aside/src/OrionAside.less
@@ -28,7 +28,7 @@
 	}
 
 	>.orion-loader {
-		border-radius: var(--o-radius-xl);
+		border-radius: var(--o-radius-md);
 	}
 
 	&:focus {
@@ -42,7 +42,7 @@
 	}
 
 	&__header {
-		padding: var(--o-space-8);
+		padding: var(--o-space-8) var(--o-space-24);
 		display: flex;
 		position: relative;
 		flex-direction: column;
@@ -53,9 +53,10 @@
 		border-bottom: 1px solid var(--o-border-neutral-default);
 
 		.orion-aside__header-container {
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
+			min-height: var(--o-height-control-xs);
+			margin-right: var(--o-space-16);
+			margin-top: var(--o-space-4);
+			margin-bottom: var(--o-space-4);
 		}
 
 		&:empty {
@@ -68,14 +69,12 @@
 	}
 
 	&__title {
-		padding-left: var(--o-space-16);
 		.typography(subtitle-bold);
 	}
 
 	&__description {
 		.typography(body2-default);
 		color: var(--o-text-default-subtle);
-		padding: 0 var(--o-space-16);
 	}
 
 	&__logo {
@@ -211,7 +210,11 @@
 		}
 	}
 
-	.orion-aside__close {}
+	&__close.orion-button {
+		position: absolute;
+		top: var(--o-space-8);
+		right: var(--o-space-8);
+	}
 
 	&--visible {
 		display: flex;

--- a/packages/Aside/src/OrionAside.vue
+++ b/packages/Aside/src/OrionAside.vue
@@ -23,31 +23,19 @@
 			</div>
 
 			<div
-				:id="`OrionAside-${setup.uid}__actions`"
-				:ref="setup._actions"
-				class="orion-aside__actions">
-				<slot
-					name="actions"
-					:close="setup.close.bind(setup)"/>
-			</div>
-			<div
 				:id="`OrionAside-${setup.uid}__header`"
 				class="orion-aside__header">
-				<h5
-					v-if="options.title"
-					class="orion-aside__title">
-					{{ options.title }}
-				</h5>
-				<span v-if="options.description">{{ options.description }}</span>
-				<slot name="header"/>
-			</div>
+				<div class="orion-aside__header-container">
+					<slot name="header"/>
+					<span
+						v-if="options.title"
+						class="orion-aside__title">
+						{{ options.title }}
+					</span>
+				</div>
 
-			<div
-				:id="`OrionAside-${setup.uid}__footer`"
-				class="orion-aside__footer">
-				<slot
-					name="footer"
-					:close="setup.close.bind(setup)"/>
+				<span v-if="options.description"  class="orion-aside__description">{{ options.description }}</span>
+
 			</div>
 
 			<div
@@ -60,17 +48,38 @@
 
 				<slot :close="setup.close.bind(setup)"/>
 			</div>
+
+			<div
+				:id="`OrionAside-${setup.uid}__actions`"
+				:ref="setup._actions"
+				class="orion-aside__actions"
+				v-show="setup.actionsHasContent">
+				<slot
+					name="actions"
+					:close="setup.close.bind(setup)"/>
+			</div>
+
+			<div
+				:id="`OrionAside-${setup.uid}__footer`"
+				:ref="setup._footer"
+				class="orion-aside__footer"
+				v-show="setup.footerHasContent">
+				<slot
+					name="footer"
+					:close="setup.close.bind(setup)"/>
+			</div>
 			<teleport
 				defer
-				:to="setup.headerIsDisplayed ? `#OrionAside-${setup.uid}__header` : `#OrionAside-${setup.uid}__body`">
-				<span
+				:to="setup.headerIsDisplayed ? `#OrionAside-${setup.uid}__header .orion-aside__header-container` : `#OrionAside-${setup.uid}__body`">
+				<o-button
 					v-if="!setup.options.hideClose"
 					class="orion-aside__close"
+					color="primary"
+					nude
+					prefix-icon="close"
 					@click="setup.close({ keepInQueue: false })"
 					@touchend.prevent.stop="setup.close({ keepInQueue: false })"/>
 			</teleport>
-
-
 			<orion-loader :ref="setup._loader"/>
 		</aside>
 	</teleport>

--- a/packages/Aside/src/OrionAside.vue
+++ b/packages/Aside/src/OrionAside.vue
@@ -13,8 +13,7 @@
 				{ 'orion-aside--visible': setup.visible },
 			]">
 			<div class="orion-aside__poster">
-				<div
-					v-if="$slots.poster">
+				<div v-if="$slots.poster">
 					<slot name="poster"/>
 				</div>
 				<div
@@ -23,19 +22,23 @@
 			</div>
 
 			<div
+				v-if="setup.displayHeader"
 				:id="`OrionAside-${setup.uid}__header`"
 				class="orion-aside__header">
 				<div class="orion-aside__header-container">
-					<slot name="header"/>
-					<span
+					<div
 						v-if="options.title"
 						class="orion-aside__title">
 						{{ options.title }}
-					</span>
+					</div>
+					<slot name="header"/>
 				</div>
 
-				<span v-if="options.description"  class="orion-aside__description">{{ options.description }}</span>
-
+				<span
+					v-if="options.description"
+					class="orion-aside__description">
+					{{ options.description }}
+				</span>
 			</div>
 
 			<div
@@ -52,8 +55,7 @@
 			<div
 				:id="`OrionAside-${setup.uid}__actions`"
 				:ref="setup._actions"
-				class="orion-aside__actions"
-				v-show="setup.actionsHasContent">
+				class="orion-aside__actions">
 				<slot
 					name="actions"
 					:close="setup.close.bind(setup)"/>
@@ -62,15 +64,17 @@
 			<div
 				:id="`OrionAside-${setup.uid}__footer`"
 				:ref="setup._footer"
-				class="orion-aside__footer"
-				v-show="setup.footerHasContent">
+				class="orion-aside__footer">
 				<slot
 					name="footer"
 					:close="setup.close.bind(setup)"/>
 			</div>
+
 			<teleport
 				defer
-				:to="setup.headerIsDisplayed ? `#OrionAside-${setup.uid}__header .orion-aside__header-container` : `#OrionAside-${setup.uid}__body`">
+				:to="setup.displayHeader
+					? `#OrionAside-${setup.uid}__header`
+					: `#OrionAside-${setup.uid}__body`">
 				<o-button
 					v-if="!setup.options.hideClose"
 					class="orion-aside__close"
@@ -80,17 +84,18 @@
 					@click="setup.close({ keepInQueue: false })"
 					@touchend.prevent.stop="setup.close({ keepInQueue: false })"/>
 			</teleport>
+
 			<orion-loader :ref="setup._loader"/>
 		</aside>
 	</teleport>
 </template>
 
 <script setup lang="ts">
-import './OrionAside.less';
-import { provide } from 'vue';
 import { OrionLoader } from 'packages/Loader';
+import { provide } from 'vue';
+import './OrionAside.less';
+import type { OrionAsideEmits, OrionAsideProps } from './OrionAsideSetupService';
 import OrionAsideSetupService from './OrionAsideSetupService';
-import type { OrionAsideProps, OrionAsideEmits } from './OrionAsideSetupService';
 const emits = defineEmits<OrionAsideEmits>() as OrionAsideEmits;
 const props = withDefaults(defineProps<OrionAsideProps>(), OrionAsideSetupService.defaultProps);
 const slots = defineSlots();

--- a/packages/Aside/src/OrionAsideSetupService.ts
+++ b/packages/Aside/src/OrionAsideSetupService.ts
@@ -1,5 +1,6 @@
 import anime from 'animejs';
-import { nextTick, reactive, ref, Slots } from 'vue';
+import { Reactive } from 'utils';
+import { ref, Slots } from 'vue';
 import SharedPopableSetupService, { SharedPopableSetupServiceEmits, SharedPopableSetupServiceProps } from '../../Shared/SharedPopableSetupService';
 
 export type OrionAsideEmits = SharedPopableSetupServiceEmits & {}
@@ -15,28 +16,17 @@ export type OrionAsideProps = SharedPopableSetupServiceProps & {
 export default class OrionAsideSetupService extends SharedPopableSetupService {
 	static readonly defaultProps = { ...SharedPopableSetupService.defaultProps };
 
-	protected name = 'OrionAside' as const;
-
+	protected readonly name = 'OrionAside' as const;
 
 	readonly _actions = ref<RefDom>();
 	readonly _footer = ref<RefDom>();
 
-	private state = reactive({
-		actionsHasContent: false,
-		footerHasContent: false,
-		actionsObserver: null as Nullable<MutationObserver>,
-		footerObserver: null as Nullable<MutationObserver>,
-	});
-
-	options = reactive<Orion.Aside.Options>({ ...this.baseOptions });
+	@Reactive readonly options: Orion.Aside.Options = { ...this.baseOptions };
 
 	get slotPoster () { return `#OrionAside-${this.uid}__poster`;}
 	get slotFooter () { return `#OrionAside-${this.uid}__footer`;}
 	get slotActions () { return `#OrionAside-${this.uid}__actions`;}
 	get slotHeader () { return `#OrionAside-${this.uid}__header`;}
-
-	get actionsHasContent () { return this.state.actionsHasContent; }
-	get footerHasContent () { return this.state.footerHasContent; }
 
 	get publicInstance () {
 		return {
@@ -55,58 +45,15 @@ export default class OrionAsideSetupService extends SharedPopableSetupService {
 
 	) {
 		super(props, emits, slots);
-
 		Object.assign(this.options, props.options);
 	}
 
 	protected onMounted () {
 		super.onMounted();
-		nextTick(() => {
-			this.initActionsObserver();
-			this.initFooterObserver();
-		});
 	}
 
 	protected onUnmounted () {
 		super.onUnmounted();
-		this.state.actionsObserver?.disconnect();
-		this.state.footerObserver?.disconnect();
-	}
-
-	private initActionsObserver () {
-		if (!this.window) return;
-		const el = this._actions.value;
-		if (!el) return;
-
-		const update = () => {
-			this.state.actionsHasContent = this.hasRenderableContent(el);
-		};
-
-		update();
-		this.state.actionsObserver = new MutationObserver(update);
-		this.state.actionsObserver.observe(el, { childList: true, subtree: false });
-	}
-
-	private initFooterObserver () {
-		if (!this.window) return;
-		const el = this._footer.value;
-		if (!el) return;
-
-		const update = () => {
-			this.state.footerHasContent = this.hasRenderableContent(el);
-		};
-
-		update();
-		this.state.footerObserver = new MutationObserver(update);
-		this.state.footerObserver.observe(el, { childList: true, subtree: false });
-	}
-
-	private hasRenderableContent (el: HTMLElement) {
-		return Array.from(el.childNodes).some((node) => {
-			if (node.nodeType === Node.ELEMENT_NODE) return true;
-			if (node.nodeType === Node.TEXT_NODE) return !!node.textContent?.trim();
-			return false;
-		});
 	}
 
 	async animateAsync (enter: boolean) {

--- a/packages/Loader/src/OrionLoader.less
+++ b/packages/Loader/src/OrionLoader.less
@@ -28,18 +28,33 @@
 	&__spinner {
 		.orion-loader--xs & {
 			.spinner(@sizeXS);
+			> .orion-icon {
+				font-size: 1rem;
+			}
 		}
 		.orion-loader--sm & {
 			.spinner(@sizeSM);
+			> .orion-icon {
+				font-size: 1.5rem;
+			}
 		}
 		.orion-loader--md & {
 			.spinner(@sizeMD);
+			> .orion-icon {
+				font-size: 2.5rem;
+			}
 		}
 		.orion-loader--lg & {
 			.spinner(@sizeLG);
+			> .orion-icon {
+				font-size: 4rem;
+			}
 		}
 		.orion-loader--xl & {
 			.spinner(@sizeXL);
+			> .orion-icon {
+				font-size: 5rem;
+			}
 		}
 	}
 

--- a/packages/Modal/src/OrionModal.vue
+++ b/packages/Modal/src/OrionModal.vue
@@ -83,7 +83,9 @@
 
 			<teleport
 				defer
-				:to="setup.headerIsDisplayed ? `#OrionModal-${setup.uid}__header` : `#OrionModal-${setup.uid}__body`">
+				:to="setup.displayHeader
+					? `#OrionModal-${setup.uid}__header`
+					: `#OrionModal-${setup.uid}__body`">
 				<span
 					v-if="!setup.options.hideClose"
 					class="orion-modal__close"
@@ -111,13 +113,13 @@ export default {
 </script>
 
 <script setup lang="ts">
-import './OrionModal.less';
-import { defineAsyncComponent, provide } from 'vue';
 import { OrionButton } from 'packages/Button';
 import { OrionLoader } from 'packages/Loader';
 import { OrionSection } from 'packages/Section';
+import { defineAsyncComponent, provide } from 'vue';
+import './OrionModal.less';
+import type { OrionModalEmits, OrionModalProps } from './OrionModalSetupService';
 import OrionModalSetupService from './OrionModalSetupService';
-import type { OrionModalProps, OrionModalEmits } from './OrionModalSetupService';
 const emits = defineEmits<OrionModalEmits>() as OrionModalEmits;
 const props = withDefaults(defineProps<OrionModalProps>(), OrionModalSetupService.defaultProps);
 const slots = defineSlots();

--- a/packages/Modal/src/OrionModalSetupService.ts
+++ b/packages/Modal/src/OrionModalSetupService.ts
@@ -1,5 +1,6 @@
 import anime from 'animejs';
-import { reactive, ref, Slots } from 'vue';
+import { Reactive } from 'utils';
+import { ref, Slots } from 'vue';
 import SharedPopableSetupService, { SharedPopableSetupServiceEmits, SharedPopableSetupServiceProps } from '../../Shared/SharedPopableSetupService';
 
 export type OrionModalEmits = SharedPopableSetupServiceEmits & {
@@ -18,12 +19,11 @@ export type OrionModalProps = SharedPopableSetupServiceProps & {
 export default class OrionModalSetupService extends SharedPopableSetupService {
 	static readonly defaultProps = { ...SharedPopableSetupService.defaultProps };
 
-	protected name = 'OrionModal' as const;
-
+	protected readonly name = 'OrionModal' as const;
 
 	readonly _prompt = ref<RefDom>();
 
-	options = reactive<Orion.Modal.Options>({ ...this.baseOptions });
+	@Reactive readonly options: Orion.Modal.Options = { ...this.baseOptions };
 
 	get promptFieldComponent () {
 		if (this.prompt) {

--- a/packages/Notif/src/OrionNotifSetupService.ts
+++ b/packages/Notif/src/OrionNotifSetupService.ts
@@ -1,6 +1,7 @@
 import anime from 'animejs';
 import { isNil } from 'lodash-es';
-import { reactive, ref } from 'vue';
+import { Reactive } from 'utils/decorators';
+import { ref } from 'vue';
 import SharedPopableSetupService, { SharedPopableSetupServiceEmits, SharedPopableSetupServiceProps } from '../../Shared/SharedPopableSetupService';
 
 export type OrionNotifEmits = SharedPopableSetupServiceEmits & {}
@@ -16,15 +17,15 @@ export type OrionNotifProps = SharedPopableSetupServiceProps & {
 export default class OrionNotifSetupService extends SharedPopableSetupService {
 	static readonly defaultProps = { ...SharedPopableSetupService.defaultProps };
 
-	protected name = 'OrionNotif' as const;
+	protected readonly name = 'OrionNotif' as const;
 
+	readonly _timerProgress = ref<HTMLElement>();
 
-	_timerProgress = ref<HTMLElement>();
-	options = reactive<Orion.Notif.Options>({
+	@Reactive readonly options: Orion.Notif.Options = {
 		...this.baseOptions,
 		overlay: false,
 		title: undefined,
-	});
+	};
 
 	private timerValue = ref<Nil<number>>();
 	private timerInterval?: NodeJS.Timeout;

--- a/packages/Section/src/OrionSection.less
+++ b/packages/Section/src/OrionSection.less
@@ -87,7 +87,8 @@ details.orion-section summary::-webkit-details-marker {
 	}
 
 	&__subtitle {
-		color: var(--o-text-default-default);
+		.typography(body2-default);
+		color: var(--o-text-default-subtle);
 		margin: 0.3rem 0 0;
 	}
 

--- a/packages/Section/src/OrionSection.vue
+++ b/packages/Section/src/OrionSection.vue
@@ -13,7 +13,7 @@
 				collapsible ? `orion-section__header--collapsible` : null,
 			]">
 			<div>
-				<h3
+				<h4
 					v-if="title"
 					class="orion-section__title">
 					{{ title }}
@@ -21,12 +21,12 @@
 						v-if="collapsible"
 						:icon="collapsed ? 'expand_more' : 'chevron_up'"
 						class="orion-section__title-chevron"/>
-				</h3>
-				<h4
+				</h4>
+				<span
 					v-if="subtitle"
 					class="orion-section__subtitle">
 					{{ subtitle }}
-				</h4>
+			</span>
 			</div>
 
 			<div

--- a/packages/Shared/SharedPopableSetupService.ts
+++ b/packages/Shared/SharedPopableSetupService.ts
@@ -41,11 +41,11 @@ export type SharedPopableSetupServiceProps = {
 export default abstract class SharedPopableSetupService extends SharedSetupService {
 	static readonly defaultProps = { options: () => ({}) as Partial<Orion.Popable.Options> };
 
-	protected abstract name: Orion.Popable.Name;
+	protected readonly abstract name: Orion.Popable.Name;
 
-	_el = ref<RefDom>();
-	_loader = ref<OrionLoader>();
-	bus = mitt();
+	readonly _el = ref<RefDom>();
+	readonly _loader = ref<OrionLoader>();
+	readonly bus = mitt();
 
 	@Reactive protected readonly state = {
 		isClosing: false,
@@ -87,7 +87,7 @@ export default abstract class SharedPopableSetupService extends SharedSetupServi
 		return { zIndex: 100 + 1 + this.zIndexBumper + this.options.zIndex };
 	}
 
-	get headerIsDisplayed () {
+	get displayHeader () {
 		return !!this.slots?.header || !!this.options.title || !!this.options.description;
 	}
 


### PR DESCRIPTION
Changements centrés sur l’Aside pour l’aligner avec le DS, avec ajustements de structure, styles et docs. L’Aside a maintenant un header structuré (titre + description), un bouton de fermeture reprenant un composant bouton, et des zones d’actions/footer repositionnées en bas avec styles cohérents.

Les slots actions/footer sont masqués automatiquement quand vides via observers. Les exemples de doc sont mis à jour (titre d’aside, footer/poster, actions, contenu imbriqué, description).

Côté Section, la hiérarchie titre/sous‑titre est ajustée (h4 + style plus subtil pour le sous‑titre).

Fichiers clés modifiés : 
- OrionAside.vue (structure header/actions/footer, close button, logique d’affichage)
- OrionAside.less (nouvelle mise en page header/footer/actions + styles DS)
- OrionAsideSetupService.ts (observers slots actions/footer)
- *.vue (exemples et textes)
- OrionSection.vue + OrionSection.less (sous‑titre plus discret)