### PR TITLE
Feature/update orion paginate

### DIFF
--- a/packages/Button/src/OrionButton.less
+++ b/packages/Button/src/OrionButton.less
@@ -168,52 +168,60 @@
 		}
 	});
 
-	&--primary {
-		&.orion-button--outline {
-			color: var(--o-text-default-default);
-			border: 1px solid var(--o-border-neutral-default);
+&--primary {
+	&.orion-button--outline {
+		color: var(--o-text-default-default);
+		border: 1px solid var(--o-border-neutral-default);
 
-			&:hover&:not(.orion-button--disabled),
-			&:focus&:not(.orion-button--disabled) {
-				background: var(--o-background-neutral-minimal);
-				border-color: var(--o-border-neutral-default);
-			}
+		&:hover&:not(.orion-button--disabled),
+		&:focus&:not(.orion-button--disabled) {
+			background: var(--o-background-neutral-minimal);
+			border-color: var(--o-border-neutral-default);
 		}
 
-		&.orion-button--nude {
-			color: var(--o-text-default-default);
-
-			&:hover&:not(.orion-button--disabled),
-			&:focus&:not(.orion-button--disabled) {
-				background: var(--o-background-neutral-subtle);
-			}
+		&.orion-button--disabled {
+			color: var(--o-text-default-disabled);
 		}
 	}
 
-	&--nude {
-		border-color: transparent !important;
-		stroke: none;
+	&.orion-button--nude {
+		color: var(--o-text-default-default);
 
-		&:not(:hover):not(:focus) {
-			background: none;
+		&:hover&:not(.orion-button--disabled),
+		&:focus&:not(.orion-button--disabled) {
+			background: var(--o-background-neutral-subtle);
+		}
+
+		&.orion-button--disabled {
+			color: var(--o-text-default-disabled);
 		}
 	}
+}
 
-	&--block {
-		width: 100%;
+&--nude {
+	border-color: transparent !important;
+	stroke: none;
+
+	&:not(:hover):not(:focus) {
+		background: none;
 	}
+}
 
-	&--disabled {
-		cursor: not-allowed;
+&--block {
+	width: 100%;
+}
+
+&--disabled {
+	cursor: not-allowed;
+}
+
+&--loading {
+	cursor: progress;
+
+	.orion-icon__loading {
+		stroke: var(--o-text-default-moderate);
 	}
-
-	&--loading {
-		cursor: progress;
-
-		.orion-icon__loading {
-			stroke: var(--o-text-default-moderate);
-		}
-	}
+}
 }
 
 @keyframes click {

--- a/packages/List/src/OrionList.vue
+++ b/packages/List/src/OrionList.vue
@@ -8,7 +8,11 @@
 			:size="page.size"
 			:total="total"
 			:bind-router="bindRouter"
-			@paginate="setup.handleOnPaginate()"/>
+			:selected-count="selected.length"
+			:variant="paginateVariant"
+			:size-options="paginateSizeOptions"
+			@paginate="setup.handleOnPaginate()"
+			@update:size="setup.handleOnPageSizeUpdate($event)"/>
 
 		<div
 			v-if="setup.computedLayout === 'grid'"
@@ -38,7 +42,11 @@
 			:size="page.size"
 			:total="total"
 			:bind-router="bindRouter"
-			@paginate="setup.handleOnPaginate()"/>
+			:selected-count="selected.length"
+			:variant="paginateVariant"
+			:size-options="paginateSizeOptions"
+			@paginate="setup.handleOnPaginate()"
+			@update:size="setup.handleOnPageSizeUpdate($event)"/>
 
 		<orion-footer-fixed
 			class="orion-footer-selected"

--- a/packages/List/src/OrionListSetupService.ts
+++ b/packages/List/src/OrionListSetupService.ts
@@ -53,6 +53,12 @@ export type OrionListProps<T extends Record<string, any>> = {
 	// @doc props/usePaginationTop displays pagination at the top of the list
 	// @doc/fr props/usePaginationTop affiche une pagination en haut de la liste
 	usePaginationTop?: boolean,
+	// @doc props/paginateVariant pagination style used by the embedded paginate component
+	// @doc/fr props/paginateVariant style de pagination utilise par le composant paginate
+	paginateVariant?: 'default' | 'detailed',
+	// @doc props/paginateSizeOptions page size options for detailed pagination
+	// @doc/fr props/paginateSizeOptions options de taille pour la pagination detaillee
+	paginateSizeOptions?: number[],
 };
 
 export default class OrionListSetupService<T extends Record<string, any>> extends SharedSetupService {
@@ -66,6 +72,7 @@ export default class OrionListSetupService<T extends Record<string, any>> extend
 		useFooterSelected: true,
 		usePaginationBottom: true,
 		usePaginationTop: true,
+		paginateVariant: 'default' as const,
 	};
 
 	get computedLayout () { return this.responsive.onPhone ? 'grid' : this.props.layout; }
@@ -116,9 +123,21 @@ export default class OrionListSetupService<T extends Record<string, any>> extend
 		this.emits('paginate', this.page.value.index);
 	}
 
+	handleOnPageSizeUpdate (size: number) {
+		const sizeValue = Number(size);
+		if (!sizeValue || isNaN(sizeValue)) return;
+		this.page.value.size = sizeValue;
+		const pagesLength = Math.ceil(this.props.total / sizeValue);
+		if (pagesLength > 0 && this.page.value.index > pagesLength) {
+			this.page.value.index = pagesLength;
+		}
+		this.emits('paginate', this.page.value.index);
+	}
+
 	listItemIsSelected (item: T): boolean {
 		return this.selected.value
 			.map(x => x[this.props.trackKey!])
 			.includes(item[this.props.trackKey!]);
 	}
 }
+

--- a/packages/Notif/src/OrionNotif.less
+++ b/packages/Notif/src/OrionNotif.less
@@ -42,7 +42,7 @@
 	&__title {
 		margin: 0;
 		color: var(--o-text-default-default);
-		line-height: 1.4295;
+		.typography(body2-bold);
 	}
 
 	&__message {

--- a/packages/Notif/src/OrionNotif.vue
+++ b/packages/Notif/src/OrionNotif.vue
@@ -14,11 +14,11 @@
 			}"/>
 		<div class="orion-notif__content">
 			<div class="orion-notif__header">
-				<h5
+				<span
 					v-if="setup.options.title"
 					class="orion-notif__title">
 					{{ setup.options.title }}
-				</h5>
+				</span>
 
 				<template v-if="setup.showTimer()">
 					<span

--- a/packages/Paginate/docs/PaginatePlayground.vue
+++ b/packages/Paginate/docs/PaginatePlayground.vue
@@ -6,14 +6,29 @@
 			:size="state.size"
 			@paginate="notifPageUpdate($event)"/>
 
+		<o-paginate
+			v-model="state.index"
+			variant="detailed"
+			:total="state.total"
+			:size="state.size"
+			@paginate="notifPageUpdate($event)"
+			@update:size="state.size = $event"/>
+
 		<o-list
 			v-model:page="state"
+			v-model:selected="selectedItems"
 			v-bind="listState"
+			:total="state.total"
+			paginate-variant="detailed"
 			:list="list">
-			<template #default="{ item }">
-				<o-card :title="item.title">
-					{{ item.description }}
-				</o-card>
+			<template #default="{ item, selected }">
+				<div @click="toggleItemSelection(item)">
+					<o-card
+						:selected="selected"
+						:title="item.title">
+						{{ item.description }}
+					</o-card>
+				</div>
 			</template>
 		</o-list>
 	</div>
@@ -49,6 +64,7 @@ import { faker } from '@faker-js/faker';
 
 const fullList = ref(seedList());
 const list = computed(() => fullList.value.slice(state.size * (state.index - 1), state.size * state.index));
+const selectedItems = reactive<any[]>([]);
 
 const state = reactive({
 	total: fullList.value.length,
@@ -58,8 +74,8 @@ const state = reactive({
 
 const listState = reactive({
 	trackKey: 'id',
-	usePaginationBottom: false,
-	usePaginationTop: false,
+	usePaginationBottom: true,
+	usePaginationTop: true,
 });
 
 function seedList (qty = 20) {
@@ -77,6 +93,13 @@ function seedList (qty = 20) {
 
 function notifPageUpdate (index: number) {
 	useNotif.info(`Active page index is now ${index}`);
+}
+
+function toggleItemSelection (item: any) {
+	const index = selectedItems.findIndex(x => x.id === item.id);
+	index > -1
+		? selectedItems.splice(index, 1)
+		: selectedItems.push(item);
 }
 
 watch(

--- a/packages/Paginate/docs/PaginatePlayground.vue
+++ b/packages/Paginate/docs/PaginatePlayground.vue
@@ -1,12 +1,9 @@
 <template>
 	<div class="flex fd-c g-16">
-		<o-paginate v-model="state.index" :total="state.total" :size="state.size" @paginate="notifPageUpdate($event)" />
+		<o-paginate v-model="state.index" :total="state.total" :size="state.size" :show-per-page="false"
+			:show-page-info="false" @paginate="notifPageUpdate($event)" @update:size="state.size = $event" />
 
-		<o-paginate v-model="state.index" variant="detailed" :total="state.total" :size="state.size"
-			:selected-count="selectedItems.length" @paginate="notifPageUpdate($event)" @update:size="state.size = $event" />
-
-		<o-list v-model:page="state" v-model:selected="selectedItems" v-bind="listState" :total="state.total"
-			paginate-variant="detailed" :list="list">
+		<o-list v-model:page="state" v-model:selected="selectedItems" v-bind="listState" :total="state.total" :list="list">
 			<template #default="{ item, selected }">
 				<div @click="toggleItemSelection(item)">
 					<o-card :selected="selected" :title="item.title">

--- a/packages/Paginate/docs/PaginatePlayground.vue
+++ b/packages/Paginate/docs/PaginatePlayground.vue
@@ -1,31 +1,15 @@
 <template>
 	<div class="flex fd-c g-16">
-		<o-paginate
-			v-model="state.index"
-			:total="state.total"
-			:size="state.size"
-			@paginate="notifPageUpdate($event)"/>
+		<o-paginate v-model="state.index" :total="state.total" :size="state.size" @paginate="notifPageUpdate($event)" />
 
-		<o-paginate
-			v-model="state.index"
-			variant="detailed"
-			:total="state.total"
-			:size="state.size"
-			@paginate="notifPageUpdate($event)"
-			@update:size="state.size = $event"/>
+		<o-paginate v-model="state.index" variant="detailed" :total="state.total" :size="state.size"
+			:selected-count="selectedItems.length" @paginate="notifPageUpdate($event)" @update:size="state.size = $event" />
 
-		<o-list
-			v-model:page="state"
-			v-model:selected="selectedItems"
-			v-bind="listState"
-			:total="state.total"
-			paginate-variant="detailed"
-			:list="list">
+		<o-list v-model:page="state" v-model:selected="selectedItems" v-bind="listState" :total="state.total"
+			paginate-variant="detailed" :list="list">
 			<template #default="{ item, selected }">
 				<div @click="toggleItemSelection(item)">
-					<o-card
-						:selected="selected"
-						:title="item.title">
+					<o-card :selected="selected" :title="item.title">
 						{{ item.description }}
 					</o-card>
 				</div>
@@ -37,22 +21,13 @@
 
 	<div class="row row--grid">
 		<div class="col-sm-4">
-			<o-input
-				v-model="state.total"
-				label="Total"
-				type="number"/>
+			<o-input v-model="state.total" label="Total" type="number" />
 		</div>
 		<div class="col-sm-4">
-			<o-input
-				v-model="state.size"
-				label="Size"
-				type="number"/>
+			<o-input v-model="state.size" label="Size" type="number" />
 		</div>
 		<div class="col-sm-4">
-			<o-input
-				v-model="state.index"
-				label="Index"
-				type="number"/>
+			<o-input v-model="state.index" label="Index" type="number" />
 		</div>
 	</div>
 </template>
@@ -74,11 +49,11 @@ const state = reactive({
 
 const listState = reactive({
 	trackKey: 'id',
-	usePaginationBottom: true,
+	usePaginationBottom: false,
 	usePaginationTop: true,
 });
 
-function seedList (qty = 20) {
+function seedList(qty = 20) {
 	const items = [];
 	for (let index = 0; index < qty; index++) {
 		items.push({
@@ -91,11 +66,11 @@ function seedList (qty = 20) {
 	return items;
 }
 
-function notifPageUpdate (index: number) {
+function notifPageUpdate(index: number) {
 	useNotif.info(`Active page index is now ${index}`);
 }
 
-function toggleItemSelection (item: any) {
+function toggleItemSelection(item: any) {
 	const index = selectedItems.findIndex(x => x.id === item.id);
 	index > -1
 		? selectedItems.splice(index, 1)

--- a/packages/Paginate/src/OrionPaginate.less
+++ b/packages/Paginate/src/OrionPaginate.less
@@ -38,6 +38,10 @@
 		width: 100%;
 	}
 
+	&__detail--center-actions {
+		justify-content: center;
+	}
+
 	&__detail-size {
 		display: flex;
 		align-items: center;
@@ -55,6 +59,10 @@
 
 	&__detail-selection--hidden {
 		visibility: hidden;
+	}
+
+	&__detail-selection--collapsed {
+		display: none;
 	}
 
 	&__detail-label,
@@ -98,26 +106,28 @@
 	}
 
 	&__input {
-
 		width: 2rem;
-		height: 2rem;
-		margin-top: 0;
-		margin-bottom: 0;
+		min-width: 2rem;
+		max-width: 2rem;
+		flex: 0 0 2rem;
 
-		&.orion-input {
+		.orion-input {
+			width: 2rem;
+			min-width: 2rem;
+			max-width: 2rem;
+			height: 2rem;
+			margin: 0;
+			padding: 0;
+		}
 
-			margin-left: 0.5rem;
-			margin-right: 0.5rem;
+		.orion-input__input {
+			padding: var(--o-space-8) var(--o-space-8);
+			text-align: center;
+		}
 
-			&__input {
-				padding: var(--o-space-8) var(--o-space-8);
-				text-align: center;
-			}
-
-			.orion-input__label {
-				max-width: unset !important;
-				left: 0.75rem;
-			}
+		.orion-input__label {
+			max-width: unset !important;
+			left: 0.75rem;
 		}
 
 		input::-webkit-outer-spin-button,

--- a/packages/Paginate/src/OrionPaginate.less
+++ b/packages/Paginate/src/OrionPaginate.less
@@ -5,18 +5,23 @@
 	position: relative;
 	display: flex;
 	justify-content: center;
+	align-items: center;
+	gap: var(--o-space-16);
 
 	&__wrapper {
 		display: flex;
+		flex: 1 1 auto;
 		align-items: center;
-		max-width: calc(100% - (2.125rem * 2));
+		justify-content: center;
+		gap: var(--o-space-4);
 	}
 
 	&__index {
-		padding: var(--o-space-16) var(--o-space-32);
+		.typography(body2-default);
 
 		&-active {
-			background: var(--o-background-info-minimal) !important;
+			background: var(--o-background-primary-minimal) !important;
+			color: var(--o-text-primary-default) !important;
 		}
 	}
 
@@ -24,18 +29,68 @@
 		padding: var(--o-space-16) var(--o-space-8);
 	}
 
-	&__prev,
-	&__next {
-		width: 2.5rem;
+	&__detail {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: var(--o-space-24);
+		width: 100%;
 	}
 
-	.orion-button {
-		border: none;
-		min-width: 2.5rem;
+	&__detail-size {
+		display: flex;
+		align-items: center;
+		gap: var(--o-space-12);
 
-		&--icon-only .icon {
-			font-size: 0.875rem;
+		.orion-select {
+			width: 70px;
 		}
+	}
+
+	&__detail-selection {
+		display: flex;
+		align-items: center;
+	}
+
+	&__detail-label,
+	&__detail-text {
+		.typography(body2-default);
+		color: var(--o-text-default);
+		white-space: nowrap;
+	}
+
+	&__detail-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--o-space-8);
+	}
+
+	&__size-select {
+		flex: 0 0 70px;
+		width: 70px;
+		min-width: 70px;
+		max-width: 70px;
+	}
+
+	&__size-select.orion-select {
+		width: 70px;
+
+		.orion-input__input {
+			width: 22px;
+			min-width: 22px;
+			max-width: 22px;
+			flex: 0 0 22px;
+			padding-right: 0 !important;
+		}
+
+		.orion-input__pictos {
+			padding: 0;
+		}
+	}
+
+	&--detailed {
+		justify-content: space-between;
 	}
 
 	&__input {
@@ -47,13 +102,14 @@
 
 		&.orion-input {
 
-		margin-left: 0.5rem;
-		margin-right: 0.5rem;
+			margin-left: 0.5rem;
+			margin-right: 0.5rem;
+
 			&__input {
 				padding: var(--o-space-8) var(--o-space-8);
 				text-align: center;
 			}
-			
+
 			.orion-input__label {
 				max-width: unset !important;
 				left: 0.75rem;
@@ -72,4 +128,3 @@
 		}
 	}
 }
-

--- a/packages/Paginate/src/OrionPaginate.less
+++ b/packages/Paginate/src/OrionPaginate.less
@@ -53,6 +53,10 @@
 		align-items: center;
 	}
 
+	&__detail-selection--hidden {
+		visibility: hidden;
+	}
+
 	&__detail-label,
 	&__detail-text {
 		.typography(body2-default);

--- a/packages/Paginate/src/OrionPaginate.vue
+++ b/packages/Paginate/src/OrionPaginate.vue
@@ -3,10 +3,10 @@
 		<template v-if="props.variant === 'detailed'">
 			<div class="orion-paginate__detail">
 				<div
-					v-if="props.selectedCount !== undefined && props.selectedCount !== null"
-					class="orion-paginate__detail-selection">
+					class="orion-paginate__detail-selection"
+					:class="{ 'orion-paginate__detail-selection--hidden': !showSelection }">
 					<span class="orion-paginate__detail-text">
-						{{ props.selectedCount }} / {{ props.total }} {{ props.selectionLabel }}
+						{{ selectedCountValue }} / {{ props.total }} {{ props.selectionLabel }}
 					</span>
 				</div>
 				<div class="orion-paginate__detail-actions">
@@ -67,6 +67,9 @@ const props = withDefaults(defineProps<OrionPaginateProps>(), OrionPaginateSetup
 const vModel = defineModel<number>({ required: true });
 const setup = new OrionPaginateSetupService(props, emits, vModel);
 defineExpose(setup.publicInstance);
+
+const showSelection = computed(() => props.selectedCount !== undefined && props.selectedCount !== null);
+const selectedCountValue = computed(() => props.selectedCount ?? 0);
 
 const sizeProxy = computed<number>({
 	get: () => props.size,

--- a/packages/Paginate/src/OrionPaginate.vue
+++ b/packages/Paginate/src/OrionPaginate.vue
@@ -1,57 +1,45 @@
 <template>
-	<div :ref="setup._el" class="orion-paginate" :class="{ 'orion-paginate--detailed': props.variant === 'detailed' }">
-		<template v-if="props.variant === 'detailed'">
-			<div class="orion-paginate__detail">
+	<div :ref="setup._el" class="orion-paginate orion-paginate--detailed">
+		<div
+			class="orion-paginate__detail"
+			:class="{ 'orion-paginate__detail--center-actions': onlyActionsVisible }">
+			<div
+				class="orion-paginate__detail-selection"
+				:class="{
+					'orion-paginate__detail-selection--hidden': !showSelection && !onlyActionsVisible,
+					'orion-paginate__detail-selection--collapsed': !showSelection && onlyActionsVisible,
+				}">
+				<span class="orion-paginate__detail-text">
+					{{ selectedCountValue }} / {{ props.total }} {{ props.selectionLabel }}
+				</span>
+			</div>
+			<div class="orion-paginate__detail-actions">
 				<div
-					class="orion-paginate__detail-selection"
-					:class="{ 'orion-paginate__detail-selection--hidden': !showSelection }">
+					v-if="showPerPage"
+					class="orion-paginate__detail-size">
+					<span class="orion-paginate__detail-label">{{ props.perPageLabel }}</span>
+					<orion-select v-model="sizeProxy" :options="setup.sizeOptions" :searchable="false" :clearable="false"
+						size="xs" class="orion-paginate__size-select" />
+				</div>
+				<div
+					v-if="showPageInfo"
+					class="orion-paginate__detail-page">
 					<span class="orion-paginate__detail-text">
-						{{ selectedCountValue }} / {{ props.total }} {{ props.selectionLabel }}
+						{{ props.pageLabel }} {{ setup.index }} {{ props.ofLabel }} {{ setup.pagesLength }}
 					</span>
 				</div>
 				<div class="orion-paginate__detail-actions">
-					<div class="orion-paginate__detail-size">
-						<span class="orion-paginate__detail-label">{{ props.perPageLabel }}</span>
-						<orion-select v-model="sizeProxy" :options="setup.sizeOptions" :searchable="false" :clearable="false"
-							size="xs" class="orion-paginate__size-select" />
-					</div>
-					<div class="orion-paginate__detail-page">
-						<span class="orion-paginate__detail-text">
-							{{ props.pageLabel }} {{ setup.index }} {{ props.ofLabel }} {{ setup.pagesLength }}
-						</span>
-					</div>
-					<div class="orion-paginate__detail-actions">
-						<orion-button outline prefix-icon="keyboard_double_arrow_left"
-							:disabled="setup.index <= 1 || setup.pagesLength <= 1" @click="setup.index = 1" />
-						<orion-button outline prefix-icon="chevron_left" :disabled="setup.index <= 1 || setup.pagesLength <= 1"
-							@click="setup.index -= 1" />
-						<orion-button outline prefix-icon="chevron_right" :disabled="setup.index >= setup.pagesLength"
-							@click="setup.index += 1" />
-						<orion-button outline prefix-icon="keyboard_double_arrow_right" :disabled="setup.index >= setup.pagesLength"
-							@click="setup.index = setup.pagesLength" />
-					</div>
+					<orion-button outline prefix-icon="keyboard_double_arrow_left"
+						:disabled="setup.index <= 1 || setup.pagesLength <= 1" @click="setup.index = 1" />
+					<orion-button outline prefix-icon="chevron_left" :disabled="setup.index <= 1 || setup.pagesLength <= 1"
+						@click="setup.index -= 1" />
+					<orion-button outline prefix-icon="chevron_right" :disabled="setup.index >= setup.pagesLength"
+						@click="setup.index += 1" />
+					<orion-button outline prefix-icon="keyboard_double_arrow_right" :disabled="setup.index >= setup.pagesLength"
+						@click="setup.index = setup.pagesLength" />
 				</div>
 			</div>
-		</template>
-		<template v-else>
-			<orion-button outline prefix-icon="chevron_left" @click="setup.index -= 1" />
-
-			<div class="orion-paginate__wrapper">
-				<template v-for="(page, i) in setup.pagesArray" :key="i">
-					<orion-button v-if="page !== '...' || (page === '...' && i === 1)" :class="[
-						{ 'orion-paginate__index-active': setup.isActive(Number(page)) },
-						{ 'orion-paginate__ellipsis': page === '...' },
-					]" :color="setup.isActive(Number(page)) ? 'primary' : 'neutral'" :disabled="page === '...'" nude
-						class="orion-paginate__index" @click="setup.index = Number(page)">
-						{{ page }}
-					</orion-button>
-					<o-input v-else v-model="setup.pageInput" placeholder="..." type="number" :max-value="setup.pagesLength"
-						:min-value="1" size="sm" class="orion-paginate__input" />
-				</template>
-			</div>
-
-			<orion-button outline suffix-icon="chevron_right" @click="setup.index += 1" />
-		</template>
+		</div>
 	</div>
 </template>
 
@@ -69,6 +57,9 @@ const setup = new OrionPaginateSetupService(props, emits, vModel);
 defineExpose(setup.publicInstance);
 
 const showSelection = computed(() => props.selectedCount !== undefined && props.selectedCount !== null);
+const showPerPage = computed(() => props.showPerPage !== false);
+const showPageInfo = computed(() => props.showPageInfo !== false);
+const onlyActionsVisible = computed(() => !showSelection.value && !showPerPage.value && !showPageInfo.value);
 const selectedCountValue = computed(() => props.selectedCount ?? 0);
 
 const sizeProxy = computed<number>({
@@ -89,4 +80,3 @@ const sizeProxy = computed<number>({
  * @doc/fr vModel/vModel vModel du composant
  */
 </script>
-

--- a/packages/Paginate/src/OrionPaginate.vue
+++ b/packages/Paginate/src/OrionPaginate.vue
@@ -1,54 +1,65 @@
 <template>
-	<div
-		:ref="setup._el"
-		class="orion-paginate">
-		<orion-button
-			nude
-			class="orion-paginate__prev"
-			prefix-icon="chevron_left"
-			@click="setup.index -= 1"/>
+	<div :ref="setup._el" class="orion-paginate" :class="{ 'orion-paginate--detailed': props.variant === 'detailed' }">
+		<template v-if="props.variant === 'detailed'">
+			<div class="orion-paginate__detail">
+				<div
+					v-if="props.selectedCount !== undefined && props.selectedCount !== null"
+					class="orion-paginate__detail-selection">
+					<span class="orion-paginate__detail-text">
+						{{ props.selectedCount }} / {{ props.total }} {{ props.selectionLabel }}
+					</span>
+				</div>
+				<div class="orion-paginate__detail-actions">
+					<div class="orion-paginate__detail-size">
+						<span class="orion-paginate__detail-label">{{ props.perPageLabel }}</span>
+						<orion-select v-model="sizeProxy" :options="setup.sizeOptions" :searchable="false" :clearable="false"
+							size="xs" class="orion-paginate__size-select" />
+					</div>
+					<div class="orion-paginate__detail-page">
+						<span class="orion-paginate__detail-text">
+							{{ props.pageLabel }} {{ setup.index }} {{ props.ofLabel }} {{ setup.pagesLength }}
+						</span>
+					</div>
+					<div class="orion-paginate__detail-actions">
+						<orion-button outline prefix-icon="keyboard_double_arrow_left"
+							:disabled="setup.index <= 1 || setup.pagesLength <= 1" @click="setup.index = 1" />
+						<orion-button outline prefix-icon="chevron_left" :disabled="setup.index <= 1 || setup.pagesLength <= 1"
+							@click="setup.index -= 1" />
+						<orion-button outline prefix-icon="chevron_right" :disabled="setup.index >= setup.pagesLength"
+							@click="setup.index += 1" />
+						<orion-button outline prefix-icon="keyboard_double_arrow_right" :disabled="setup.index >= setup.pagesLength"
+							@click="setup.index = setup.pagesLength" />
+					</div>
+				</div>
+			</div>
+		</template>
+		<template v-else>
+			<orion-button outline prefix-icon="chevron_left" @click="setup.index -= 1" />
 
-		<div
-			class="orion-paginate__wrapper">
-			<template
-				v-for="(page, i) in setup.pagesArray"
-				:key="i">
-				<orion-button
-					v-if="page !== '...' || (page === '...' && i === 1 )"
-					:class="[
+			<div class="orion-paginate__wrapper">
+				<template v-for="(page, i) in setup.pagesArray" :key="i">
+					<orion-button v-if="page !== '...' || (page === '...' && i === 1)" :class="[
 						{ 'orion-paginate__index-active': setup.isActive(Number(page)) },
 						{ 'orion-paginate__ellipsis': page === '...' },
-					]"
-					:color="setup.isActive(Number(page)) ? 'primary' : 'neutral'"
-					:disabled="page === '...'"
-					nude
-					class="orion-paginate__index"
-					@click="setup.index = Number(page)">
-					{{ page }}
-				</orion-button>
-				<o-input
-					v-else
-					v-model="setup.pageInput"
-					placeholder="..."
-					type="number"
-					:max-value="setup.pagesLength"
-					:min-value="1"
-					size="sm"
-					class="orion-paginate__input"/>
-			</template>
-		</div>
+					]" :color="setup.isActive(Number(page)) ? 'primary' : 'neutral'" :disabled="page === '...'" nude
+						class="orion-paginate__index" @click="setup.index = Number(page)">
+						{{ page }}
+					</orion-button>
+					<o-input v-else v-model="setup.pageInput" placeholder="..." type="number" :max-value="setup.pagesLength"
+						:min-value="1" size="sm" class="orion-paginate__input" />
+				</template>
+			</div>
 
-		<orion-button
-			nude
-			class="orion-paginate__next"
-			suffix-icon="chevron_right"
-			@click="setup.index += 1"/>
+			<orion-button outline suffix-icon="chevron_right" @click="setup.index += 1" />
+		</template>
 	</div>
 </template>
 
 <script setup lang="ts">
 import './OrionPaginate.less';
+import { computed } from 'vue';
 import { OrionButton } from 'packages/Button';
+import { OrionSelect } from 'packages/Select';
 import OrionPaginateSetupService from './OrionPaginateSetupService';
 import type { OrionPaginateProps, OrionPaginateEmits } from './OrionPaginateSetupService';
 const emits = defineEmits<OrionPaginateEmits>() as OrionPaginateEmits;
@@ -57,8 +68,22 @@ const vModel = defineModel<number>({ required: true });
 const setup = new OrionPaginateSetupService(props, emits, vModel);
 defineExpose(setup.publicInstance);
 
+const sizeProxy = computed<number>({
+	get: () => props.size,
+	set: (val) => {
+		const sizeValue = Number(val);
+		if (!sizeValue || isNaN(sizeValue)) return;
+		emits('update:size', sizeValue);
+		const pagesLength = Math.ceil(props.total / sizeValue);
+		if (pagesLength > 0 && setup.index > pagesLength) {
+			setup.index = pagesLength;
+		}
+	},
+});
+
 /** Doc
  * @doc vModel/vModel component's vModel
  * @doc/fr vModel/vModel vModel du composant
  */
 </script>
+

--- a/packages/Paginate/src/OrionPaginateSetupService.ts
+++ b/packages/Paginate/src/OrionPaginateSetupService.ts
@@ -7,12 +7,36 @@ export type OrionPaginateEmits = {
 	// @doc event/paginate/desc emitted on page changement
 	// @doc/fr event/paginate/desc émis au changement de page
 	(e: 'paginate', payload: number): void;
+	// @doc event/update-size/desc emitted when the page size changes
+	// @doc/fr event/update-size/desc emis quand la taille de page change
+	(e: 'update:size', payload: number): void;
 }
 
 export type OrionPaginateProps = {
 	// @doc props/bindRouter the key used in the url query to get the current active page (ex: ...url/my-list?**page**=2 • *bindRouter = **page***)
 	// @doc/fr props/bindRouter représente la clé utilisée dans l'url pour déterminer la page active actuelle (ex: ...url/my-list?**page**=2 • *bindRouter = **page***)
 	bindRouter?: string,
+	// @doc props/selectedCount number of selected rows displayed in detailed mode
+	// @doc/fr props/selectedCount nombre de lignes selectionnees affichees en mode detailed
+	selectedCount?: number,
+	// @doc props/selectionLabel label displayed after the selected count in detailed mode
+	// @doc/fr props/selectionLabel libelle affiche apres le compteur de selection en mode detailed
+	selectionLabel?: string,
+	// @doc props/variant pagination style (default or detailed)
+	// @doc/fr props/variant style de pagination (default ou detailed)
+	variant?: 'default' | 'detailed',
+	// @doc props/sizeOptions page size options displayed in detailed mode
+	// @doc/fr props/sizeOptions options de taille de page affichees en mode detailed
+	sizeOptions?: number[],
+	// @doc props/perPageLabel label displayed next to the page size selector in detailed mode
+	// @doc/fr props/perPageLabel libelle affiche pres du selecteur de taille en mode detailed
+	perPageLabel?: string,
+	// @doc props/pageLabel label displayed before the current page value in detailed mode
+	// @doc/fr props/pageLabel libelle affiche avant la valeur de page en mode detailed
+	pageLabel?: string,
+	// @doc props/ofLabel label displayed between current page and total pages in detailed mode
+	// @doc/fr props/ofLabel libelle affiche entre la page courante et le total en mode detailed
+	ofLabel?: string,
 	// @doc props/size number of elements to display on each page
 	// @doc/fr props/size nombre d'éléments à afficher sur chaque page
 	size: number,
@@ -23,7 +47,14 @@ export type OrionPaginateProps = {
 
 export default class OrionPaginateSetupService extends SharedSetupService {
 
-	static readonly defaultProps = {};
+	static readonly defaultProps = {
+		variant: 'default' as const,
+		sizeOptions: () => [10, 20, 50, 100],
+		perPageLabel: 'Lignes par page',
+		pageLabel: 'Page',
+		ofLabel: 'sur',
+		selectionLabel: 'ligne(s) sélectionnées',
+	};
 
 	@Reactive protected readonly state = { pageInput: undefined as Undef<number> };
 
@@ -31,8 +62,8 @@ export default class OrionPaginateSetupService extends SharedSetupService {
 		this.index = +val;
 	}, 500);
 
-	get pageInput () { return this.state.pageInput; }
-	set pageInput (val) {
+	get pageInput() { return this.state.pageInput; }
+	set pageInput(val) {
 		this.state.pageInput = val;
 		if (val) {
 			this.debouncedUpdate(val);
@@ -40,14 +71,14 @@ export default class OrionPaginateSetupService extends SharedSetupService {
 
 	}
 
-	get index () {
+	get index() {
 		if (this.props.bindRouter && this.router.currentRoute.value.query[this.props.bindRouter]) {
 			return Number(this.router.currentRoute.value.query[this.props.bindRouter]);
 		}
 		return this.vModel.value;
 	}
 
-	set index (val) {
+	set index(val) {
 		if (val < 1 || val > this.pagesLength || isNaN(val) || val === this.index) return;
 		this.vModel.value = val;
 		this.emits('paginate', val);
@@ -66,7 +97,7 @@ export default class OrionPaginateSetupService extends SharedSetupService {
 
 	}
 
-	get pagesArray () {
+	get pagesArray() {
 		const a = [];
 		if (this.vModel.value < 5 || this.pagesLength === 5) {
 			for (let index = 1; index <= (this.pagesLength < 6 ? this.pagesLength : 4); index++) {
@@ -80,7 +111,7 @@ export default class OrionPaginateSetupService extends SharedSetupService {
 			a.push(1);
 			a.push('...');
 			const indexFor = this.pagesLength - 3;
-			for (let index = indexFor; index < this.pagesLength -2; index++) {
+			for (let index = indexFor; index < this.pagesLength - 2; index++) {
 				a.push(index);
 			}
 		} else {
@@ -88,7 +119,7 @@ export default class OrionPaginateSetupService extends SharedSetupService {
 			a.push('...');
 			if (this.vModel.value !== this.pagesLength) {
 				const indexFor = this.vModel.value - 2;
-				for (let index = indexFor; index <= (this.vModel.value + 2 > this.pagesLength -1 ? this.pagesLength -1 : this.vModel.value + 2); index++) {
+				for (let index = indexFor; index <= (this.vModel.value + 2 > this.pagesLength - 1 ? this.pagesLength - 1 : this.vModel.value + 2); index++) {
 					a.push(index);
 				}
 			} else {
@@ -104,19 +135,32 @@ export default class OrionPaginateSetupService extends SharedSetupService {
 		return a;
 	}
 
-	get pagesLength () {
+	get pagesLength() {
 		return Math.ceil(this.props.total / this.props.size);
 	}
 
-	constructor (protected props: OrionPaginateProps, protected emits: OrionPaginateEmits, protected vModel: ModelRef<number>) {
+	get sizeOptions() {
+		const options = this.props.sizeOptions?.length
+			? this.props.sizeOptions
+			: [10, 20, 50, 100];
+		return options.includes(this.props.size)
+			? options
+			: [...options, this.props.size].sort((a, b) => a - b);
+	}
+
+
+	constructor(protected props: OrionPaginateProps, protected emits: OrionPaginateEmits, protected vModel: ModelRef<number>) {
 		super();
 	}
 
 
-	isActive (page?: number) {
+	isActive(page?: number) {
 		if (this.props.bindRouter && this.router.currentRoute.value.query[this.props.bindRouter]) {
 			return Number(this.router.currentRoute.value.query[this.props.bindRouter]) === page;
 		}
 		return page === this.index;
 	}
 }
+
+
+

--- a/packages/Paginate/src/OrionPaginateSetupService.ts
+++ b/packages/Paginate/src/OrionPaginateSetupService.ts
@@ -22,6 +22,12 @@ export type OrionPaginateProps = {
 	// @doc props/selectionLabel label displayed after the selected count in detailed mode
 	// @doc/fr props/selectionLabel libelle affiche apres le compteur de selection en mode detailed
 	selectionLabel?: string,
+	// @doc props/showPerPage toggles the per-page selector in detailed mode
+	// @doc/fr props/showPerPage affiche ou masque le selecteur de lignes par page en mode detailed
+	showPerPage?: boolean,
+	// @doc props/showPageInfo toggles the page indicator in detailed mode
+	// @doc/fr props/showPageInfo affiche ou masque l'indicateur de page en mode detailed
+	showPageInfo?: boolean,
 	// @doc props/variant pagination style (default or detailed)
 	// @doc/fr props/variant style de pagination (default ou detailed)
 	variant?: 'default' | 'detailed',
@@ -54,6 +60,8 @@ export default class OrionPaginateSetupService extends SharedSetupService {
 		pageLabel: 'Page',
 		ofLabel: 'sur',
 		selectionLabel: 'ligne(s) sélectionnées',
+		showPerPage: true,
+		showPageInfo: true,
 	};
 
 	@Reactive protected readonly state = { pageInput: undefined as Undef<number> };
@@ -161,6 +169,7 @@ export default class OrionPaginateSetupService extends SharedSetupService {
 		return page === this.index;
 	}
 }
+
 
 
 


### PR DESCRIPTION
Objectif :
- Passer OrionPaginate en version “detailed” uniquement et mettre à jour le playground pour refléter le nouveau rendu.
- Ajouter le compteur de sélection (avec espace réservé si masqué), et des options d’affichage pour “Lignes par page” et l’info de page.
- Ajuster le layout (largeur du select, alignements) et centrer les actions quand le reste est masqué.

Pourquoi :
- Aligner la pagination sur le design “detailed” et offrir une configuration fine de l’affichage.